### PR TITLE
RFC: pre json filters  for `Plot`s

### DIFF
--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -3,6 +3,7 @@ module PlotlyJS
 using JSON
 using Blink
 using Colors
+using Base.Dates
 
 # globals for this package
 const _js_path = joinpath(dirname(dirname(@__FILE__)),
@@ -21,6 +22,7 @@ type Plot{TT<:AbstractTrace}
 end
 
 # include the rest of the core parts of the package
+include("filters.jl")
 include("json.jl")
 include("display.jl")
 include("subplots.jl")
@@ -55,6 +57,11 @@ export
     extendtraces, prependtraces,
 
     # helper methods
-    plot, fork, vline, hline, attr
+    plot, fork, vline, hline, attr,
+
+    # filters
+    set_color_cycle!, set_layout_defaults!, reset_color_cycle!,
+    reset_layout_defaults!, use_style!
+
 
 end # module

--- a/src/api.jl
+++ b/src/api.jl
@@ -2,8 +2,9 @@
 # Standard Julia API methods #
 # -------------------------- #
 
-prep_kwarg(pair::Tuple) = (symbol(replace(string(pair[1]), "_", ".")), pair[2])
-prep_kwargs(pairs::Vector) = Dict(map(prep_kwarg, pairs))
+prep_kwarg(pair::Union{Pair,Tuple}) =
+    (symbol(replace(string(pair[1]), "_", ".")), pair[2])
+prep_kwargs(pairs::Union{Associative,Vector}) = Dict(map(prep_kwarg, pairs))
 
 """
 `size(::PlotlyJS.Plot)`

--- a/src/display.jl
+++ b/src/display.jl
@@ -4,20 +4,18 @@
 
 function html_body(p::Plot)
     """
-    <div id="$(p.divid)"></div>
+    <div id="$(p.divid)" class="plotly-graph-div"></div>
 
     <script>
+        window.PLOTLYENV=window.PLOTLYENV || {};
+        window.PLOTLYENV.BASE_URL="https://plot.ly";
        $(script_content(p))
      </script>
     """
 end
 
 script_content(p::Plot) = """
-    thediv = document.getElementById('$(p.divid)');
-    var data = $(json(p.data))
-    var layout = $(json(p.layout))
-
-    Plotly.plot(thediv, data,  layout, {showLink: false});
+    Plotly.newPlot('$(p.divid)', $(json(p.data)),  $(json(p.layout)), {showLink: false});
     """
 
 

--- a/src/displays/electron.jl
+++ b/src/displays/electron.jl
@@ -132,8 +132,8 @@ redraw!(p::ElectronDisplay) =
 # unexported (by plotly.js) api methods
 extendtraces!(ed::ElectronDisplay, update::Associative=Dict(),
               indices::Vector{Int}=[1], maxpoints=-1;) =
-    @js_ p Plotly.extendTraces(this, $update, $(indices-1), $maxpoints)
+    @js_ ed Plotly.extendTraces(this, $(prep_kwargs(update)), $(indices-1), $maxpoints)
 
 prependtraces!(ed::ElectronDisplay, update::Associative=Dict(),
                indices::Vector{Int}=[1], maxpoints=-1;) =
-    @js_ p Plotly.prependTraces(this, $update, $(indices-1), $maxpoints)
+    @js_ ed Plotly.prependTraces(this, $(prep_kwargs(update)), $(indices-1), $maxpoints)

--- a/src/displays/electron.jl
+++ b/src/displays/electron.jl
@@ -46,6 +46,10 @@ end
 function Base.display(p::ElectronPlot)
     w = get_window(p)
     loadjs(p.view)
+
+    # apply current filters
+    for f in values(_pre_json_filters) f(p.plot) end
+    
     @js w begin
         trydiv = document.getElementById($(string(p.plot.divid)))
         if trydiv == nothing

--- a/src/displays/ijulia.jl
+++ b/src/displays/ijulia.jl
@@ -39,6 +39,8 @@ if isdefined(Main, :IJulia) && Main.IJulia.inited
         if p.view.displayed
             Dict()
         else
+            # apply current filters
+            for f in values(_pre_json_filters) f(p.plot) end
             p.view.displayed = true
             Dict("text/html" => html_body(p.plot))
         end

--- a/src/displays/ijulia.jl
+++ b/src/displays/ijulia.jl
@@ -14,21 +14,40 @@ JupyterPlot(p::Plot) = JupyterPlot(p, JupyterDisplay(p))
 
 fork(jp::JupyterPlot) = JupyterPlot(fork(jp.plot))
 
+const _jupyter_js_loaded = [false]
+js_loaded(::JupyterDisplay) = _jupyter_js_loaded[1]
+js_loaded(::Type{JupyterDisplay}) = _jupyter_js_loaded[1]
+
+function html_body(p::JupyterPlot)
+    """
+    <div id="$(p.divid)" class="plotly-graph-div"></div>
+
+    <script>
+        window.PLOTLYENV=window.PLOTLYENV || {};
+        window.PLOTLYENV.BASE_URL="https://plot.ly";
+        require(['plotly'], function(Plotly) {
+            $(script_content(p))
+        });
+     </script>
+    """
+end
+
 # if we're in IJulia call setupnotebook to load js and css
 if isdefined(Main, :IJulia) && Main.IJulia.inited
     # borrowed from https://github.com/plotly/plotly.py/blob/2594076e29584ede2d09f2aa40a8a195b3f3fc66/plotly/offline/offline.py#L64-L71
-    display("text/html", """
-        <script type='text/javascript'>
-            define('plotly', function(require, exports, module) {
-                $(open(readall, _js_path, "r"))
-            });
-            require(['plotly'], function(Plotly) {
-                window.Plotly = Plotly;
-            });
-        </script>
-    """)
-    display("text/html", "<p>Plotly javascript loaded.</p>")
-    js_loaded(::JupyterDisplay) = true
+    if !js_loaded(JupyterDisplay)
+        display("text/html", """
+            <script type='text/javascript'>
+                define('plotly', function(require, exports, module) {
+                    $(open(readall, _js_path, "r"))
+                });
+                require(['plotly'], function(Plotly) {
+                    window.Plotly = Plotly;
+                });
+            </script>""")
+        _jupyter_js_loaded[1] = true
+        display("text/html", "<p>Plotly javascript loaded.</p>")
+    end
 
     @eval import IJulia
 
@@ -42,14 +61,9 @@ if isdefined(Main, :IJulia) && Main.IJulia.inited
             # apply current filters
             for f in values(_pre_json_filters) f(p.plot) end
             p.view.displayed = true
-            Dict("text/html" => html_body(p.plot))
+            Dict("text/html" => html_body(p))
         end
     end
-
-    # TODO: maybe add Blink.js to this page and we can reuse all the same api
-    # methods?
-else
-    js_loaded(::JupyterDisplay) = false
 end
 
 ## API Methods for JupyterDisplay

--- a/src/filters.jl
+++ b/src/filters.jl
@@ -1,0 +1,65 @@
+# ------------------- #
+# Pre-display filters #
+# ------------------- #
+
+const _pre_json_filters = Dict{Symbol,Function}()
+
+
+function set_color_cycle!(colors::Vector)
+    n = length(colors)
+
+    function _cycle!(p::Plot)
+        ix = 1
+        for t in p.data
+            if haskey(t["marker"], :color)
+                # don't override if the user already set this
+                continue
+            else
+                t["marker.color"] = colors[ix]
+                ix = ix == n ? 1 : ix + 1
+            end
+        end
+    end
+
+    _pre_json_filters[:color_cycle] = _cycle!
+end
+
+function set_layout_defaults!(l::Layout)
+
+    function _update_layout!(p::Plot)
+        # list p.layout last to preserve settings the user manually applied
+        p.layout.fields = merge(l, p.layout)
+    end
+    _pre_json_filters[:layout_defaults] = _update_layout!
+end
+
+reset_color_cycle!() =
+    (pop!(_pre_json_filters, :color_cycle, nothing); nothing)
+
+reset_layout_defaults!() =
+    (pop!(_pre_json_filters, :layout_defaults, nothing); nothing)
+
+function use_style!(sty::Symbol)
+    if sty == :ggplot
+        axis_attrs = attr(showgrid=true, gridcolor="white", linewidth=1.0,
+                          linecolor="white", titlefont_color="#555555",
+                          titlefont_size=12, ticks="outside",
+                          tickcolor="#555555"
+                          )
+        layout = Layout(Dict{Symbol,Any}(:plot_bgcolor => "#E5E5E5",
+                                         :paper_bgcolor => "white");
+                        font_size=10,
+                        xaxis=axis_attrs,
+                        yaxis=axis_attrs,
+                        titlefont_size=14)
+        set_layout_defaults!(layout)
+        set_color_cycle!(["#E24A33", "#348ABD", "#988ED5", "#777777",
+                          "#FBC15E", "#8EBA42", "#FFB5B8"])
+    elseif sty == :default
+        reset_layout_defaults!()
+        reset_color_cycle!()
+    else
+        error("Uknown style $sty")
+    end
+
+end

--- a/src/traces_layouts.jl
+++ b/src/traces_layouts.jl
@@ -46,8 +46,6 @@ function attr(fields=Dict{Symbol,Any}(); kwargs...)
     s
 end
 
-Base.merge(a::PlotlyAttribute, d::Dict) = merge(a.fields, d)
-
 abstract AbstractLayoutAttribute
 abstract AbstractShape <: AbstractLayoutAttribute
 
@@ -146,6 +144,9 @@ hline(y, fields::Associative=Dict{Symbol,Any}(); kwargs...) =
 # ---------------------------------------- #
 
 typealias HasFields Union{GenericTrace,Layout,Shape,PlotlyAttribute}
+
+Base.merge(hf::HasFields, d::Dict) = merge(hf.fields, d)
+Base.merge{T<:HasFields}(hf1::T, hf2::T) = merge(hf1.fields, hf2.fields)
 
 # methods that allow you to do `obj["first.second.third"] = val`
 Base.setindex!(gt::HasFields, val, key::ASCIIString) =

--- a/src/traces_layouts.jl
+++ b/src/traces_layouts.jl
@@ -34,8 +34,9 @@ kind(l::Layout) = "layout"
 # -------------------------------------------- #
 # Specific types of trace or layout attributes #
 # -------------------------------------------- #
+abstract AbstractPlotlyAttribute
 
-type PlotlyAttribute{T<:Associative{Symbol,Any}}
+type PlotlyAttribute{T<:Associative{Symbol,Any}} <: AbstractPlotlyAttribute
     fields::T
 end
 
@@ -46,10 +47,10 @@ function attr(fields=Dict{Symbol,Any}(); kwargs...)
     s
 end
 
-abstract AbstractLayoutAttribute
+abstract AbstractLayoutAttribute <: AbstractPlotlyAttribute
 abstract AbstractShape <: AbstractLayoutAttribute
 
-kind{T<:Union{PlotlyAttribute,AbstractLayoutAttribute}}(::T) = string(T)
+kind{T<:AbstractPlotlyAttribute}(::T) = string(T)
 
 # TODO: maybe loosen some day
 typealias _Scalar Union{Base.Dates.Date,Number,AbstractString}
@@ -147,10 +148,11 @@ typealias HasFields Union{GenericTrace,Layout,Shape,PlotlyAttribute}
 
 Base.merge(hf::HasFields, d::Dict) = merge(hf.fields, d)
 Base.merge{T<:HasFields}(hf1::T, hf2::T) = merge(hf1.fields, hf2.fields)
+Base.get(hf::HasFields, k::Symbol, default) = get(hf.fields, k, default)
 
 # methods that allow you to do `obj["first.second.third"] = val`
 Base.setindex!(gt::HasFields, val, key::ASCIIString) =
-    setindex!(gt, val, map(symbol, split(key, "."))...)
+    setindex!(gt, val, map(symbol, split(key, ['.', '_']))...)
 
 Base.setindex!(gt::HasFields, val, keys::ASCIIString...) =
     setindex!(gt, val, map(symbol, keys)...)
@@ -161,7 +163,7 @@ Base.setindex!(gt::HasFields, val, keys::ASCIIString...) =
 function Base.setindex!(gt::HasFields, val, key::Symbol)
     # check if single key has underscores, if so split at str and call above
     if contains(string(key), "_")
-        return setindex!(gt, val, replace(string(key), "_", "."))
+        return setindex!(gt, val, string(key))
     end
     gt.fields[key] = val
 end
@@ -197,12 +199,15 @@ end
 # now on to the simpler getindex methods. They will try to get the desired
 # key, but if it doesn't exist an empty dict is returned
 Base.getindex(gt::HasFields, key::ASCIIString) =
-    getindex(gt, map(symbol, split(key, "."))...)
+    getindex(gt, map(symbol, split(key, ['.', '_']))...)
 
 Base.getindex(gt::HasFields, keys::ASCIIString...) =
     getindex(gt, map(symbol, keys)...)
 
 function Base.getindex(gt::HasFields, key::Symbol)
+    if contains(string(key), "_")
+        return getindex(gt, string(key))
+    end
     get(gt.fields, key, Dict())
 end
 

--- a/test/traces.jl
+++ b/test/traces.jl
@@ -1,11 +1,17 @@
 
-gt = M.GenericTrace("scatter"; x=1:10, y=sin(1:10))
+gt = M.GenericTrace("scatter"; x=1:10, y=sin(1:10), marker_color="red")
 
 @testset "test constructors" begin
     @test sort(collect(keys(gt.fields))) == [:x, :y]
 end
 
 @testset "test setindex!, getindex methods" begin
+    # test that getindex with a symbol that has underscores retrieves nested
+    # attribute
+    @test gt["marker_color"] == "red"
+    @test gt["marker.color"] == "red"
+    @test gt[:marker_color] == "red"
+
     gt[:visible] = true
     @test length(gt.fields) == 3
     @test haskey(gt.fields, :visible)


### PR DESCRIPTION
Here's an idea I'm experimenting with, but am not 100% sold on.

I've added a global:

``` julia
const _pre_json_filters = Dict{Symbol,Function}()
```

That will collect functions with the signature `f(::Plot)`. The idea is that immediately before displaying a plot (using any frontnbd (electron or the notebook)), all functions in `values(_pre_json_filters)` will be called to filter the plot before display.

Some cool things this enables in a pretty straightforward way:
- setting [color cycles](https://github.com/spencerlyon2/PlotlyJS.jl/blob/0398f6043efa67db0f89ddffe786b6cccf87b0d7/src/filters.jl#L8-L25) a la matplotlib
- Creating Gadfly-esque themes or matplotlib-esque [styles](https://github.com/spencerlyon2/PlotlyJS.jl/blob/0398f6043efa67db0f89ddffe786b6cccf87b0d7/src/filters.jl#L42-L65)
- Processing special types of data. @ssfrr had an example of adding a `layout.ticksuffix` when `x` or `y` for a trace was a `Vector{T<:SIQuantity}`. We could also handle converting `Colors.Colorants` to hex strings. The main value of doing these things this way is that we can isolate interactions with other packages in an `@require` block
- Swapping out similar filters by changing the value associated with a particular `key` in the dict (e.g. swapping color cycles)
- completely removing filters by just `pop!`ing the key off the dict

Some downsides:
- We rely on a **_mutable global_** (:shudder:) that mutates plot objects when they are displayed. I see at least two problems with this:
  1. a mutable global can lead to inconsistent behavior across sessions (what if I loaded a package that triggered a new filter in the previous session, but I haven't done that in the current session?)
  2. `display` becomes an impure function as the `Plot` object passed in will not be the same before and after calling `display`

Any comments?

cc: @cc7768 @tbreloff @ssfrr @MikeInnes @malmaud 
