### PR TITLE
[WIP] fixes restyling for stem plots

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -61,6 +61,12 @@ end
 _apply_restyle_setindex!(hf::Union{Associative,HasFields}, k::Symbol, v, i::Int) =
     setindex!(hf, v, k)
 
+# enable the same automatic indexing behavior but for setfield!
+_apply_restyle_setfield!(obj, k::Symbol, v::Union{AbstractArray,Tuple}, i::Int) =
+    setfield!(obj, k, v[i])
+
+_apply_restyle_setfield!(obj, k::Symbol, v, i::Int) = setfield!(obj, k, v)
+
 
 #=
 Wrap the vector so it repeats to be at least length N

--- a/src/convenience_api.jl
+++ b/src/convenience_api.jl
@@ -97,6 +97,7 @@ end
 
 Base.setindex!(st::StemTrace, args...; kwargs...) = setindex!(st.trace, args...; kwargs...)
 Base.getindex(st::StemTrace, args...; kwargs...) = getindex(st.trace, args...; kwargs...)
+Base.get(st::StemTrace, args...; kwargs...) = get(st.trace, args...; kwargs...)
 JSON.lower(st::StemTrace) = JSON.lower(st.trace)
 kind(trace::StemTrace) = :scatter
 
@@ -177,8 +178,6 @@ function _update_stemfields(st::StemTrace)
             :color => st.stem_color,
             :width => 0,
             :thickness => st.stem_thickness)
-    else
-        println("got no y data")
     end
 
     nothing

--- a/src/traces_layouts.jl
+++ b/src/traces_layouts.jl
@@ -1,3 +1,4 @@
+# subtypes of AbstractTrace should have a "fields" field that's an Associative
 abstract AbstractTrace
 abstract AbstractLayout
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ end
 
 using PlotlyJS
 typealias M PlotlyJS
+using JSON
 
 try
     @testset DottedTestSet "PlotlyJS Tests" begin

--- a/test/stem.jl
+++ b/test/stem.jl
@@ -1,0 +1,103 @@
+# lowered stem plot, for testing
+lstem(args...; kwargs...) = stem(args...; kwargs...) |> JSON.lower
+
+import PlotlyJS: AbstractPlotlyDisplay, SyncPlot, restyle!, prep_kwargs
+
+# calls is a list of calls to the display backend. Each call is recorded as a
+# string with the name of the function, and an Array of the arguments as they'd
+# be called down to javascript
+type MockPlotlyDisplay <: AbstractPlotlyDisplay
+    calls::Array{Tuple{String, Array{Any}}}
+
+    MockPlotlyDisplay() = new(Any[])
+end
+
+# TODO: this mimics what electron.jl does, it would be better to bubble this
+# logic up before the various displays are called, so we can have a simpler mock
+function restyle!(disp::MockPlotlyDisplay, I, update::Associative=Dict(); kwargs...)
+    argdict = merge(update, prep_kwargs(kwargs))
+    push!(disp.calls, ("restyle!", [argdict, I-1]))
+    println("\nrestyle!")
+    println(argdict)
+end
+
+function restyle!(disp::MockPlotlyDisplay, update::Associative=Dict(); kwargs...)
+    argdict = merge(update, prep_kwargs(kwargs))
+    push!(disp.calls, ("restyle!", [argdict]))
+    println("\nrestyle!")
+    println(argdict)
+end
+
+@testset "stem plot construction" begin
+    st = lstem()
+    @test st[:type] == "scatter"
+
+    data = rand(5)
+    st = lstem(y=data)
+    @test st[:type] == "scatter"
+    @test st[:mode] == "markers"
+    @test st[:hoverinfo] == "text"
+    @test st[:y] == data
+    @test st[:text] == data
+    @test st[:marker][:size] == 10
+    @test st[:error_y][:type] == "data"
+    @test st[:error_y][:symmetric] == false
+    @test st[:error_y][:array] == -min(data, 0)
+    @test st[:error_y][:arrayminus] == max(data, 0)
+    @test st[:error_y][:visible] == true
+    @test st[:error_y][:color] == "grey"
+    @test st[:error_y][:width] == 0
+    @test st[:error_y][:thickness] == 1
+
+    st = lstem(y=data, stem_color="red", stem_thickness=5)
+    @test st[:error_y][:color] == "red"
+    @test st[:error_y][:thickness] == 5
+
+    @test_throws ErrorException stem(y=rand(5), mode="lines")
+    @test_throws ErrorException stem(y=rand(5), error_y=attr(value=rand(5)))
+end
+
+@testset "stem plot restyling" begin
+    data = rand(5)
+    p = Plot(stem(y=data))
+
+    data = rand(5)
+    restyle!(p, y=[data])
+    st = JSON.lower(p.data[1])
+    @test st[:y] == data
+    @test st[:error_y][:array] == -min(data, 0)
+    @test st[:error_y][:arrayminus] == max(data, 0)
+
+    restyle!(p, stem_thickness=5, stem_color="red")
+    @test st[:error_y][:thickness] == 5
+    @test st[:error_y][:color] == "red"
+end
+
+@testset "SyncPlot restyling" begin
+    data = rand(5)
+    syncplot = SyncPlot(Plot(stem(y=data)), MockPlotlyDisplay())
+
+    data = rand(5)
+    restyle!(syncplot, y=[data], stem_thickness=5)
+    st = JSON.lower(syncplot.plot.data[1])
+    # first make sure the julia-side plot got updated
+    @test st[:y] == data
+    @test st[:error_y][:array] == -min(data, 0)
+    @test st[:error_y][:arrayminus] == max(data, 0)
+
+    # make sure the right display function got called
+    @test length(syncplot.view.calls) == 1
+    call = syncplot.view.calls[1]
+    @test call[1] == "restyle!"
+    @test call[2][1] == Dict(
+        :y => [data],
+        :error_y => Dict(
+            :type => "data",
+            :symmetric => false,
+            :array => -min(data, 0),
+            :arrayminus => max(data, 0),
+            :visible => true,
+            :color => "grey",
+            :width => 0,
+            :thickness => 5))
+end


### PR DESCRIPTION
Seems to be working, and passes existing tests. I also added new tests for the previous stem plot behavior and now restyling. To test that the javascript stuff is getting called correctly I added a `MockPlotlyDisplay` type that partially mocks the API for the other displays so I can make sure things are getting called correctly.

There are a few cleanup things that I think would be good to do, but they involve more change to existing code, so I wanted to check in beforehand to see if you're on-board, and/or whether you'd want these changes as a separate PR:

* [ ] refactor `AbstractPlotlyDisplay` API so that the low-level methods (like `restyle!`) don't do any argument transformation and JUST forward the calls through to javascript. That way the `MockPlotlyDisplay` doesn't have to copy-paste behavior from the other displays.
* [ ] bump up `MockPlotlyDisplay` to top-level of tests so it can be used by other tests outside the `stem` stuff
* [ ] move additional `scatter` test in with the rest of the `scatter` tests
* [ ] the fact that many functions (internal and external) use both an update dict and keyword args complicates a lot of the implementation. I propose we merge/normalize to a dict as soon as we get the args from the user, and then all the internal functions just use the dict.