### PR TITLE
Readall rename and Js loading default

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -30,7 +30,7 @@ function stringmime(::MIME"text/html", p::Plot, js::Symbol=:local)
     elseif js == :remote
         script_txt = "<script src=\"$(_js_cdn_path)\"></script>"
     elseif js == :embed
-        script_txt = "<script>$(readall(_js_path))</script>"
+        script_txt = "<script>$(@compat readstring(_js_path))</script>"
     else
         msg = """
         Unknown value for argument js: $js.

--- a/src/display.jl
+++ b/src/display.jl
@@ -22,8 +22,9 @@ function script_content(p::Plot)
     """
 end
 
+const js_default = Ref(:local)
 
-function stringmime(::MIME"text/html", p::Plot, js::Symbol=:local)
+function stringmime(::MIME"text/html", p::Plot, js::Symbol=js_default[])
 
     if js == :local
         script_txt = "<script src=\"$(_js_path)\"></script>"
@@ -52,7 +53,7 @@ function stringmime(::MIME"text/html", p::Plot, js::Symbol=:local)
 
 end
 
-@compat Base.show(io::IO, ::MIME"text/html", p::Plot, js::Symbol=:local) =
+@compat Base.show(io::IO, ::MIME"text/html", p::Plot, js::Symbol=js_default[]) =
     print(io, stringmime(MIME"text/html"(), p, js))
 
 @compat function Base.show(io::IO, ::MIME"text/plain", p::Plot)
@@ -111,7 +112,7 @@ for f in (:extendtraces!, :prependtraces!)
     end
 end
 
-@compat Base.show(io::IO, ::MIME"text/html", sp::SyncPlot, js::Symbol=:local) =
+@compat Base.show(io::IO, ::MIME"text/html", sp::SyncPlot, js::Symbol=js_default[]) =
     print(io, stringmime(MIME"text/html"(), sp.plot, js))
 
 # Add some basic Julia API methods on SyncPlot that just forward onto the Plot

--- a/src/savefig.jl
+++ b/src/savefig.jl
@@ -42,7 +42,7 @@ end
     - `:remote` - reference the javascript from plotly CDN
     - `:embed` - embed the javascript in output (add's 1.7MB to size)
 """
-function savefig_imagemagick(p::ElectronPlot, fn::AbstractString; js::Symbol=:local
+function savefig_imagemagick(p::ElectronPlot, fn::AbstractString; js::Symbol=js_default[]
                              #   sz::Tuple{Int,Int}=(8,6),
                              #   dpi::Int=300
                              )
@@ -102,7 +102,7 @@ function savefig_imagemagick(p::ElectronPlot, fn::AbstractString; js::Symbol=:lo
     p
 end
 
-function savefig(p::ElectronPlot, fn::AbstractString; js::Symbol=:local)
+function savefig(p::ElectronPlot, fn::AbstractString; js::Symbol=js_default[])
     suf = split(fn, ".")[end]
 
     # if html we don't need a plot window


### PR DESCRIPTION
* `readall` has been renamed to `readstring` on Julia 0.6
* Enables setting a default js loading preference. Doesn't change current behaviour but enables having plotly.js javascript file loaded via embed or from cdn by default.

InteractNext will set `js_default` to :embed (using Requires.jl - [code here](https://github.com/JuliaGizmos/InteractNext.jl/blob/plotly-js-default/src/setup.jl#L19)) which will make it easier to support PlotlyJS in Mux, Blink, and Juno.

