### PR TITLE
Sl/cyclers

### DIFF
--- a/docs/styles.md
+++ b/docs/styles.md
@@ -3,7 +3,6 @@ defined as an instance of the following type:
 
 ```julia
 struct Style
-    color_cycle::Vector
     layout::Layout
     global_trace::PlotlyAttribute
     trace::Dict{Symbol,PlotlyAttribute}
@@ -12,13 +11,49 @@ end
 
 Let's go over the fields one by one:
 
-- `color_cycle`: A vector of color-like objects that defines a sequence of
-colors to be applied to the `marker.color` attribute of a trace
 - `layout`: A `Layout` object defining style attributes for the layout
 - `global_trace`: A `PlotlyAttribute` (created with the `attr` function) that
 contains trace attributes to be applied to traces of all types
 - `trace`: A dictionary mapping trace types into attributes to be applied to
 that type of trace
+
+## `Cycler`s
+
+Starting with v0.7.1, PlotlyJS.jl has a new type called `Cycler` that can be
+used to set style properties that should be cycled through for each trace.
+
+For example, to have all traces alternate between being colored green and red,
+I could define:
+
+```julia
+mystyle = Style(global_trace=attr(marker_color=["green", "red"]))
+```
+
+If I were then to define a plot
+
+```julia
+p = plot(rand(10, 3), style=mystyle)
+```
+
+The first and third plots would be green, while the second would be red.
+
+As usual, if the `marker_color` attribute on a trace was already set, then
+it will not be altered. For example:
+
+```julia
+p = plot(
+    [
+        scatter(y=rand(4)),
+        scatter(y=rand(4), marker_color="black"),
+        scatter(y=rand(4)),
+        scatter(y=rand(4)),
+    ],
+    style=mystyle
+)
+```
+
+Then the first and fourth traces would be red, the second black, and the third
+green.
 
 ## Defining `Style`s
 

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -79,11 +79,14 @@ ggplot = let
                     yaxis=axis,
                     titlefont_size=14)
 
-    gta = attr(marker_line_width=0.5, marker_line_color="#348ABD")
-
-    colors = ["#E24A33", "#348ABD", "#988ED5", "#777777", "#FBC15E",
-              "#8EBA42", "#FFB5B8"]
-    Style(layout=layout, color_cycle=colors, global_trace=gta)
+    colors = [
+        "#E24A33", "#348ABD", "#988ED5", "#777777", "#FBC15E",
+        "#8EBA42", "#FFB5B8"
+    ]
+    gta = attr(
+        marker_line_width=0.5, marker_line_color="#348ABD", marker_color=colors
+    )
+    Style(layout=layout, global_trace=gta)
 end
 ```
 
@@ -91,7 +94,6 @@ When displayed in the REPL we see the following:
 
 ```
 Style with:
-  - color_cycle: String["#E24A33","#348ABD","#988ED5","#777777","#FBC15E","#8EBA42","#FFB5B8"]
   - layout with fields font, margin, paper_bgcolor, plot_bgcolor, titlefont, xaxis, and yaxis
   - global_trace: PlotlyAttribute with field marker
 ```
@@ -116,7 +118,6 @@ When displayed in the REPL we see the following:
 
 ```
 Style with:
-  - color_cycle: String["#E24A33","#348ABD","#988ED5","#777777","#FBC15E","#8EBA42","#FFB5B8"]
   - layout with fields font, margin, paper_bgcolor, plot_bgcolor, titlefont, xaxis, and yaxis
   - global_trace: PlotlyAttribute with field marker
   - trace:

--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -122,7 +122,7 @@ export
     init_notebook,
 
     # styles
-    use_style!, style, Style
+    use_style!, style, Style, Cycler
 
 
 ## borrowed from Compose.jl

--- a/test/styles.jl
+++ b/test/styles.jl
@@ -3,7 +3,6 @@ ps2 = M.Style(layout=M.Layout(font_family="Helvetica"))
 
 @testset "Style(::Style, ::Style)" begin
     ps3 = M.Style(ps1, ps2)
-    @test isempty(ps3.color_cycle)
     @test ps3.layout[:font] == Dict(:family=>"Helvetica", :size=>10)
     @test isempty(ps3.global_trace)
     @test isempty(ps3.trace)
@@ -14,7 +13,6 @@ ps2 = M.Style(layout=M.Layout(font_family="Helvetica"))
     ps5 = M.Style(new_font, gg)
 
     # make sure things were set properly
-    @test ps4.color_cycle == ps5.color_cycle == gg.color_cycle
     for (k, v) in gg.layout
         if k == :font
             want = gg.layout[:font]
@@ -29,11 +27,15 @@ end
 
 @testset "setting plot attributes" begin
 
-    goofy = Style(global_trace=attr(marker_color="red"),
-                  trace=Dict(:scatter => attr(mode="markers")))
+    goofy = Style(
+        global_trace=attr(
+            marker_color="red", line_dash=Cycler(["dash", "dot"]),
+        ),
+        trace=Dict(:scatter => attr(mode="markers")),
+    )
 
     p1 = Plot(scatter(y=1:3, mode="lines", marker_symbol="square"), style=goofy)
-    p2 = Plot(scatter(y=1:3, marker_color="green"), style=goofy)
+    p2 = Plot(scatter(y=1:3, marker_color="green", line_dash="dot"), style=goofy)
 
     # now call JSON.lower to enforce style
     PlotlyJS.JSON.lower(p1)
@@ -41,4 +43,17 @@ end
 
     @test p1.data[1]["marker_color"] == "red"
     @test p2.data[1]["marker_color"] == "green"
+
+    @test p1.data[1]["line_dash"] == "dash"
+    @test p2.data[1]["line_dash"] == "dot"
+
+    p3 = Plot(rand(5, 6), style=goofy)
+    restyle!(p3, 4, line_dash="something_else")
+    PlotlyJS.JSON.lower(p3)
+    @test p3.data[1]["line_dash"] == "dash"
+    @test p3.data[2]["line_dash"] == "dot"
+    @test p3.data[3]["line_dash"] == "dash"
+    @test p3.data[4]["line_dash"] == "something_else"
+    @test p3.data[5]["line_dash"] == "dot"
+    @test p3.data[6]["line_dash"] == "dash"
 end


### PR DESCRIPTION
Adds a `Cycler` type that can be used to create trace attributes that should be cycled through when defining styles.

Generalizes the behavior we were using `style.color_cycle` for to alter the `marker_color` attribute.

See the docs: https://github.com/sglyon/PlotlyJS.jl/blob/sl/cyclers/docs/styles.md#cyclers