### PR TITLE
Tiny Cycler fixes

### DIFF
--- a/docs/styles.md
+++ b/docs/styles.md
@@ -191,7 +191,7 @@ There are a few built in styles that come with PlotlyJS.jl. More will be added
 over time. To see which styles are currently built in look at the unexported
 `PlotlyJS.STYLES` variable.
 
-To obtain a built in style use the method `Style(s::Symbol)`, where `s` is one
+To obtain a built in style use the method `style(s::Symbol)`, where `s` is one
 of the symbols in `PlotlyJS.STYLES`.
 
 To use a built in style globally use the method `use_style!(s::Symbol)`, where

--- a/src/styles.jl
+++ b/src/styles.jl
@@ -17,11 +17,10 @@ Base.length(c::Cycler) = length(c.vals)
 Cycler(t::Tuple) = Cycler(collect(t))
 Cycler(x::Union{String,Number,Date,Symbol}) = Cycler([x])
 
-function Base.getindex(c::Cycler, ix::Int)
-    ix < 1 && error("index must be positive")
+function Base.getindex(c::Cycler, ix::Integer)
     n = length(c.vals)
-    _i = rem(ix, n)
-    c.vals[ifelse(_i > 0, _i, n)]
+    @inbounds v = c.vals[mod1(ix, n)]
+    v
 end
 
 function Base.getindex(c::Cycler, ixs::AbstractVector{<:Integer})

--- a/src/styles.jl
+++ b/src/styles.jl
@@ -13,7 +13,7 @@ struct Cycler
 end
 
 Base.isempty(c::Cycler) = isempty(c.vals)
-Base.length(c::Cycler) = length(c.vals˚)
+Base.length(c::Cycler) = length(c.vals)
 Cycler(t::Tuple) = Cycler(collect(t))
 Cycler(x::Union{String,Number,Date,Symbol}) = Cycler([x])
 

--- a/test/styles.jl
+++ b/test/styles.jl
@@ -1,3 +1,13 @@
+@testset "Cycler" begin
+    cycl = Cycler([:a, :b, :c])
+    @test length(cycl) == 3
+    @test !isempty(cycl)
+    @test cycl[1] == :a
+    @test cycl[5] == :b
+    @test cycl[3:7] == [:c, :a, :b, :c, :a]
+    @test_throws Exception cycl[0]
+end
+
 ps1 = M.Style(layout=M.Layout(font_size=10))
 ps2 = M.Style(layout=M.Layout(font_family="Helvetica"))
 

--- a/test/styles.jl
+++ b/test/styles.jl
@@ -5,7 +5,9 @@
     @test cycl[1] == :a
     @test cycl[5] == :b
     @test cycl[3:7] == [:c, :a, :b, :c, :a]
-    @test_throws Exception cycl[0]
+    @test cycl[0] == :c
+    @test cycl[-1] == :b
+    @test cycl[-2:1] == [:a, :b, :c, :a]
 end
 
 ps1 = M.Style(layout=M.Layout(font_size=10))


### PR DESCRIPTION
Fix typo in `length(Cycler)` and use `mod1()` in `getindex()`.