### PR TITLE
[WIP/RFC[ Refactor subplots API

### DIFF
--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -124,7 +124,10 @@ export
     init_notebook,
 
     # styles
-    use_style!, style, Style, Cycler
+    use_style!, style, Style, Cycler,
+
+    # subplots
+    arrange
 
 
 ## borrowed from Compose.jl

--- a/src/subplots.jl
+++ b/src/subplots.jl
@@ -1,6 +1,6 @@
 """
 Given the number of rows and columns, return an NTuple{4,Float64} containing
-`(width, height, vspace, hspace)`, where `width` and `height` are the
+`(width, height, hspace, vspace)`, where `width` and `height` are the
 width and height of each subplot and `vspace` and `hspace` are the vertical
 and horizonal spacing between subplots, respectively.
 """
@@ -12,11 +12,11 @@ function sizes(nr::Int, nc::Int, subplot_titles::Bool=false)
     height = (1. - dy * (nr - 1)) / nr
     vspace = nr == 1 ? 0.0 : (1 - height*nr)/(nr-1)
     hspace = nc == 1 ? 0.0 : (1 - width*nc)/(nc-1)
-    width, height, vspace, hspace
+    width, height, hspace, vspace
 end
 
 function gen_layout(nr, nc, subplot_titles::Bool=false)
-    w, h, dy, dx = sizes(nr, nc, subplot_titles)
+    w, h, dx, dy = sizes(nr, nc, subplot_titles)
 
     x = 0.0  # start from left
     y = 1.0  # start from top

--- a/src/subplots.jl
+++ b/src/subplots.jl
@@ -4,7 +4,7 @@ Given the number of rows and columns, return an NTuple{4,Float64} containing
 width and height of each subplot and `vspace` and `hspace` are the vertical
 and horizonal spacing between subplots, respectively.
 """
-function sizes(nr::Int, nc::Int, subplot_titles::Bool=false)
+function subplot_size(nr::Int, nc::Int, subplot_titles::Bool=false)
     # NOTE: the logic of this function was mostly borrowed from plotly.py
     dx = 0.2 / nc
     dy = subplot_titles ? 0.55 / nr : 0.3 / nr
@@ -16,7 +16,7 @@ function sizes(nr::Int, nc::Int, subplot_titles::Bool=false)
 end
 
 function gen_layout(nr, nc, subplot_titles::Bool=false)
-    w, h, dx, dy = sizes(nr, nc, subplot_titles)
+    w, h, dx, dy = subplot_size(nr, nc, subplot_titles)
 
     x = 0.0  # start from left
     y = 1.0  # start from top

--- a/src/subplots.jl
+++ b/src/subplots.jl
@@ -39,18 +39,19 @@ function subplots_layout(nr, nc, subplot_titles::Bool=false)
     out
 end
 
+hastitle(layout::Layout) = haskey(layout.fields, "title") || haskey(layout.fields, :title)
+hastitle(plot::Plot) = hastitle(plot.layout)
+
 function handle_titles!(big_layout, sub_layout, ix::Int)
-    # don't worry about it if the sub_layout doesn't have a title
-    if !haskey(sub_layout.fields, "title") && !haskey(sub_layout.fields, :title)
-        return big_layout
-    end
+    hastitle(sub_layout) || return big_layout
 
     # check for symbol or string
-    nm = haskey(sub_layout.fields, "title") ? "title" : :title
+    subtitle = pop!(sub_layout.fields, haskey(sub_layout.fields, "title") ? "title" : :title)
 
+    # add text annotation with the subplot title
     ann = Dict{Any,Any}(:font => Dict{Any,Any}(:size => 16),
                         :showarrow => false,
-                        :text => pop!(sub_layout.fields, nm),
+                        :text => subtitle,
                         :x => mean(big_layout["xaxis$(ix).domain"]),
                         :xanchor => "center",
                         :xref => "paper",
@@ -65,8 +66,7 @@ end
 
 function _cat(nr::Int, nc::Int, ps::Plot...)
     copied_plots = Plot[copy(p) for p in ps]
-    subplot_titles = any(map(x -> haskey(x.layout.fields, :title) ||
-                                  haskey(x.layout.fields, "title"), ps))
+    subplot_titles = any(hastitle, ps)
     layout = subplots_layout(nr, nc, subplot_titles)
 
     for col in 1:nc, row in 1:nr

--- a/src/subplots.jl
+++ b/src/subplots.jl
@@ -15,7 +15,7 @@ function subplot_size(nr::Int, nc::Int, subplot_titles::Bool=false)
     width, height, hspace, vspace
 end
 
-function gen_layout(nr, nc, subplot_titles::Bool=false)
+function subplots_layout(nr, nc, subplot_titles::Bool=false)
     w, h, dx, dy = subplot_size(nr, nc, subplot_titles)
 
     out = Layout()
@@ -67,7 +67,7 @@ function _cat(nr::Int, nc::Int, ps::Plot...)
     copied_plots = Plot[copy(p) for p in ps]
     subplot_titles = any(map(x -> haskey(x.layout.fields, :title) ||
                                   haskey(x.layout.fields, "title"), ps))
-    layout = gen_layout(nr, nc, subplot_titles)
+    layout = subplots_layout(nr, nc, subplot_titles)
 
     for col in 1:nc, row in 1:nr
         ix = sub2ind((nc, nr), col, row)

--- a/src/subplots.jl
+++ b/src/subplots.jl
@@ -42,7 +42,7 @@ end
 hastitle(layout::Layout) = haskey(layout.fields, "title") || haskey(layout.fields, :title)
 hastitle(plot::Plot) = hastitle(plot.layout)
 
-function handle_titles!(big_layout, sub_layout, ix::Int)
+function add_subplot_annotation!(big_layout::Layout, sub_layout::Layout, ix::Integer)
     hastitle(sub_layout) || return big_layout
 
     # check for symbol or string
@@ -77,7 +77,7 @@ function _cat(nr::Int, nc::Int, ps::Plot...)
             trace["yaxis"] = "y$ix"
         end
 
-        handle_titles!(layout, copied_plots[ix].layout, ix)
+        add_subplot_annotation!(layout, copied_plots[ix].layout, ix)
         layout["xaxis$ix"] = merge(copied_plots[ix].layout["xaxis"], layout["xaxis$ix"])
         layout["yaxis$ix"] = merge(copied_plots[ix].layout["yaxis"], layout["yaxis$ix"])
     end

--- a/src/subplots.jl
+++ b/src/subplots.jl
@@ -18,29 +18,25 @@ end
 function gen_layout(nr, nc, subplot_titles::Bool=false)
     w, h, dx, dy = subplot_size(nr, nc, subplot_titles)
 
-    x = 0.0  # start from left
-    y = 1.0  # start from top
-
     out = Layout()
+
+    x = 0.0  # start from left
     for col in 1:nc
 
-        y = 1.0 # reset y as we start a new col
+        y = 1.0  # start from top
         for row in 1:nr
-            subplot = sub2ind((nc, nr), col, row)
+            subplot = sub2ind((nr, nc), row, col)
 
-            out["xaxis$subplot"] = Dict{Any,Any}(:domain=>[x, x+w],
-                                                 :anchor=> "y$subplot")
-            out["yaxis$subplot"] = Dict{Any,Any}(:domain=>[y-h, y],
-                                                 :anchor=> "x$subplot")
+            out["xaxis$subplot"] = Dict{Any,Any}(:domain=>[x, x+w], :anchor=> "y$subplot")
+            out["yaxis$subplot"] = Dict{Any,Any}(:domain=>[y-h, y], :anchor=> "x$subplot")
 
-            y -= nr == 1 ? 0.0 : h + dy
-         end
+            y -= h + dy
+        end
 
-         x += nc == 1 ? 0.0 : w + dx
+        x += w + dx
     end
 
     out
-
 end
 
 function handle_titles!(big_layout, sub_layout, ix::Int)


### PR DESCRIPTION
While trying to work with subplots, I've found the current API somewhat "toxic": since PlotlyJS overrides `Base.[v|h|hv]cat()` methods, almost any operation with plot arrays results in an automatic construction of a combined plot.

Instead, I propose not to touch `Base` methods and define `PlotlyJS.arrange()` (my first idea was to call it `combine()`, but it's already used by DataFrames, and it's not good to have the same name since both packages are likely to be used together). The generic `arrange(layout::Layout, subplots::AbstractVector{<:Plot})` would build a combined plot with user-defined layout (the correctness of layout is not checked).

To replace `[v|h|hv]cat()` there are `arrange(subplots::Vector/Matrix)` methods.
They automatically generate one-column or matrix layouts, respectively, and call the generic `arrange()`.
`arrange(subplots_vector')` (note the transpose) would generate one-row layout.

So far I hadn't touched any unit tests and didn't test it extensively.
Also I proposed more descriptive names for a few subplots-related methods.

Let me know if you think it's a step in a right direction.

In future it should be possible to extend `arrange()` and provide convenience methods for customized layout generation (irregular grid size, row/col spans, customized axes anchoring).