### PR TITLE
webio integration

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -121,6 +121,7 @@ Base.copy(sp::SyncPlot) = fork(sp)  # defined by each SyncPlot{TD}
 # ----------------- #
 
 @require Juno include("displays/juno.jl")
+@require WebIO include("displays/webio.jl")
 include("displays/electron.jl")
 include("displays/ijulia.jl")
 

--- a/src/displays/webio.jl
+++ b/src/displays/webio.jl
@@ -1,0 +1,13 @@
+WebIO.render(p::SyncPlot) = WebIO.render(p.plot)
+
+function WebIO.render(p::Plot)
+    scp = WebIO.Scope(imports = ["plotly" => _js_path])
+    scp.dom = WebIO.Node(:div, id = string(p.divid), className = "plotly-graph-div")
+    WebIO.onimport(scp, WebIO.js"""function (Plotly) {
+        window.PLOTLYENV=window.PLOTLYENV || {};
+        window.PLOTLYENV.BASE_URL="https://plot.ly";
+        $(WebIO.JSString(PlotlyJS.script_content(p)))
+    }
+    """)
+    WebIO.render(scp)
+end


### PR DESCRIPTION
This defines a `WebIO.render` method for PlotlyJS plot objects, so that they work out of the box withing a InteractBase GUI. The current solution involves a nasty hack setting the PlotlyJS default from within InteractBase so that it embeds the javascript and I'd like to get rid of that hack (it's also horrible performance-wise). 

This can go as soon as the PlotlyWebIO story is complete, but I think it's a good stop-gap solution till then, as I'm really not comfortable with [this code](https://github.com/piever/InteractBase.jl/blob/master/src/package_support.jl).