### PR TITLE
Fixes for Julia v0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ notifications:
 # uncomment the following lines to override the default test script
 script:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
- - xvfb-run julia -e 'using Pkg; clone(pwd()); build("PlotlyJS"); test("PlotlyJS"; coverage=true)'
+ - xvfb-run julia -e 'using Pkg; Pkg.add(PackageSpec(url=pwd())); Pkg.build("PlotlyJS"); Pkg.test("PlotlyJS"; coverage=true)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 os:
   - linux
 julia:
-  - 0.6
+  - 0.7
   - nightly
 matrix:
   allow_failures:
@@ -20,4 +20,4 @@ notifications:
 # uncomment the following lines to override the default test script
 script:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
- - xvfb-run julia -e 'Pkg.clone(pwd()); Pkg.build("PlotlyJS"); Pkg.test("PlotlyJS"; coverage=true)'
+ - xvfb-run julia -e 'using Pkg; clone(pwd()); build("PlotlyJS"); test("PlotlyJS"; coverage=true)'

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,3 +4,5 @@ Blink 0.3.3
 DocStringExtensions
 Requires
 PlotlyBase 0.1.2
+Reexport 0.2.0
+Compat 0.69

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7
 JSON 0.7
 Blink 0.3.3
 DocStringExtensions

--- a/deps/find_attr_groups.jl
+++ b/deps/find_attr_groups.jl
@@ -1,9 +1,10 @@
 module AttrGroups
 
 using JSON
+using Compat: AbstractDict
 
 _symbol_dict(x) = x
-_symbol_dict(d::Associative) =
+_symbol_dict(d::AbstractDict) =
     Dict{Symbol,Any}([(Symbol(k), _symbol_dict(v)) for (k, v) in d])
 
 function main()
@@ -11,7 +12,7 @@ function main()
     data = _symbol_dict(JSON.parsefile(joinpath(@__DIR__, "plotschema.json")))
 
     nms = Set{Symbol}()
-    function add_to_names!(d::Associative)
+    function add_to_names!(d::AbstractDict)
         map(add_to_names!, keys(d))
         map(add_to_names!, values(d))
         nothing

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -32,12 +32,12 @@ two abstract types):
 abstract AbstractTrace
 abstract AbstractLayout
 
-type GenericTrace{T<:Associative{Symbol,Any}} <: AbstractTrace
+type GenericTrace{T<:AbstractDict{Symbol,Any}} <: AbstractTrace
     kind::ASCIIString
     fields::T
 end
 
-type Layout{T<:Associative{Symbol,Any}} <: AbstractLayout
+type Layout{T<:AbstractDict{Symbol,Any}} <: AbstractLayout
     fields::T
 end
 

--- a/docs/build_example_docs.jl
+++ b/docs/build_example_docs.jl
@@ -36,7 +36,7 @@ function single_file(filename::String)
     open(joinpath(this_dir, "examples", filename[1:end-3]*".md"), "w") do outfile
 
     # Read lines from a files
-    fulltext = open(readstring, joinpath(this_dir, "..", "examples", filename), "r")
+    fulltext = open(f->read(f, String), joinpath(this_dir, "..", "examples", filename), "r")
     all_lines = split(fulltext, "\n")
     l = 1
     regex = r"^function ([^_].+?)\("

--- a/docs/building_traces_layouts.md
+++ b/docs/building_traces_layouts.md
@@ -9,13 +9,13 @@ A `Plot` instance will have a vector of `trace`s. These should each be a subtype
 PlotlyJS.jl defines one such subtype:
 
 ```julia
-type GenericTrace{T<:Associative{Symbol,Any}} <: AbstractTrace
+type GenericTrace{T<:AbstractDict{Symbol,Any}} <: AbstractTrace
     kind::ASCIIString
     fields::T
 end
 ```
 
-The `kind` field specifies the type of trace and the `fields` is an Associative object that maps trace attributes to their values.
+The `kind` field specifies the type of trace and the `fields` is an AbstractDict object that maps trace attributes to their values.
 
 Let's consider an example. Suppose we would like to build the following JSON
 object:
@@ -239,7 +239,7 @@ julia> println(JSON.json(t1, 2))
 The `Layout` type is defined as
 
 ```julia
-type Layout{T<:Associative{Symbol,Any}} <: AbstractLayout
+type Layout{T<:AbstractDict{Symbol,Any}} <: AbstractLayout
     fields::T
 end
 ```

--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -6,6 +6,7 @@ using Reexport
 @reexport using PlotlyBase
 using JSON
 using Base.Iterators
+using Compat: AbstractDict
 
 # need to import some functions because methods are meta-generated
 import PlotlyBase:

--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -53,7 +53,7 @@ function docs()
         Blink.load!(w.content, f)
         wait(w.content)
     end
-    Blink.content!(w, "html", open(readstring, schema_path), fade=false)
+    Blink.content!(w, "html", open(f->read(f, String), schema_path), fade=false)
 end
 
 export

--- a/src/display.jl
+++ b/src/display.jl
@@ -98,7 +98,7 @@ for f in (:extendtraces!, :prependtraces!)
             ($f)(p, [ind], maxpoints; update...)
         end
 
-        function $(f)(p::AbstractPlotlyDisplay, update::Associative, ind::Int,
+        function $(f)(p::AbstractPlotlyDisplay, update::AbstractDict, ind::Int,
                       maxpoints=-1)
             ($f)(p, update, [ind], maxpoints)
         end

--- a/src/display.jl
+++ b/src/display.jl
@@ -30,7 +30,7 @@ function stringmime(::MIME"text/html", p::Plot, js::Symbol=js_default[])
     elseif js == :remote
         script_txt = "<script src=\"$(_js_cdn_path)\"></script>"
     elseif js == :embed
-        script_txt = "<script>$(readstring(_js_path))</script>"
+        script_txt = "<script>$(read(_js_path, String))</script>"
     else
         msg = """
         Unknown value for argument js: $js.

--- a/src/displays/electron.jl
+++ b/src/displays/electron.jl
@@ -241,15 +241,15 @@ Blink.js(p::ElectronPlot, code::JSString; callback=true) =
     Blink.js(p.view, code; callback=callback)
 
 # Methods from javascript API (docstrings found in api.jl)
-function relayout!(p::ElectronDisplay, update::Associative=Dict(); kwargs...)
+function relayout!(p::ElectronDisplay, update::AbstractDict=Dict(); kwargs...)
     @js_ p begin reset_svg(); Plotly.relayout(this, $(merge(update, prep_kwargs(kwargs)))).then(save_svg) end
 end
 
-function restyle!(p::ElectronDisplay, ind::Int, update::Associative=Dict(); kwargs...)
+function restyle!(p::ElectronDisplay, ind::Int, update::AbstractDict=Dict(); kwargs...)
     @js_ p begin reset_svg(); Plotly.restyle(this, $(merge(update, prep_kwargs(kwargs))), $(ind-1)).then(save_svg) end
 end
 
-function restyle!(p::ElectronDisplay, inds::AbstractVector{Int}, update::Associative=Dict(); kwargs...)
+function restyle!(p::ElectronDisplay, inds::AbstractVector{Int}, update::AbstractDict=Dict(); kwargs...)
     @js_ p begin reset_svg(); Plotly.restyle(this, $(merge(update, prep_kwargs(kwargs))), $(inds-1)).then(save_svg) end
 end
 
@@ -257,11 +257,11 @@ function restyle!(p::ElectronDisplay, update=Dict(); kwargs...)
     @js_ p begin reset_svg(); Plotly.restyle(this, $(merge(update, prep_kwargs(kwargs)))).then(save_svg) end
 end
 
-function update!(p::ElectronDisplay, ind::Int, update::Associative=Dict(); layout::Layout=Layout(), kwargs...)
+function update!(p::ElectronDisplay, ind::Int, update::AbstractDict=Dict(); layout::Layout=Layout(), kwargs...)
     @js_ p begin reset_svg(); Plotly.update(this, $(merge(update, prep_kwargs(kwargs))), $(layout), $(ind-1)).then(save_svg) end
 end
 
-function update!(p::ElectronDisplay, inds::AbstractVector{Int}, update::Associative=Dict(); layout::Layout=Layout(), kwargs...)
+function update!(p::ElectronDisplay, inds::AbstractVector{Int}, update::AbstractDict=Dict(); layout::Layout=Layout(), kwargs...)
     @js_ p begin reset_svg(); Plotly.update(this, $(merge(update, prep_kwargs(kwargs))), $(layout), $(inds-1)).then(save_svg) end
 end
 
@@ -306,12 +306,12 @@ function download_image(p::ElectronDisplay; kwargs...)
 end
 
 # unexported (by plotly.js) api methods
-function extendtraces!(ed::ElectronDisplay, update::Associative=Dict(),
+function extendtraces!(ed::ElectronDisplay, update::AbstractDict=Dict(),
               indices::Vector{Int}=[1], maxpoints=-1;)
     @js_ ed begin reset_svg(); Plotly.extendTraces(this, $(prep_kwargs(update)), $(indices-1), $maxpoints).then(save_svg) end
 end
 
-function prependtraces!(ed::ElectronDisplay, update::Associative=Dict(),
+function prependtraces!(ed::ElectronDisplay, update::AbstractDict=Dict(),
                indices::Vector{Int}=[1], maxpoints=-1;)
     @js_ ed begin reset_svg(); Plotly.prependTraces(this, $(prep_kwargs(update)), $(indices-1), $maxpoints).then(save_svg) end
 end

--- a/src/displays/electron.jl
+++ b/src/displays/electron.jl
@@ -4,13 +4,13 @@
 
 mutable struct ElectronDisplay <: AbstractPlotlyDisplay
     divid::Base.Random.UUID
-    w::Nullable{Any}
+    w
 end
 
 const ElectronPlot = SyncPlot{ElectronDisplay}
 
-ElectronDisplay() = ElectronDisplay(Base.Random.uuid4(), Nullable())
-ElectronDisplay(divid::Base.Random.UUID) = ElectronDisplay(divid, Nullable())
+ElectronDisplay() = ElectronDisplay(Base.Random.uuid4(), nothing)
+ElectronDisplay(divid::Base.Random.UUID) = ElectronDisplay(divid, nothing)
 ElectronDisplay(p::Plot) = ElectronDisplay(p.divid)
 ElectronPlot(p::Plot) = ElectronPlot(p, ElectronDisplay(p.divid))
 
@@ -21,7 +21,7 @@ PlotlyBase.fork(jp::ElectronPlot) = ElectronPlot(fork(jp.plot), ElectronDisplay(
 """
 Return true if the display has been initialized and is still open, else false
 """
-isactive(ed::ElectronDisplay) = isnull(ed.w) ? false : Blink.active(get(ed.w))
+isactive(ed::ElectronDisplay) = ed.w === nothing ? false : Blink.active(get(ed.w))
 
 """
 If the display is active, close the window
@@ -59,7 +59,7 @@ creates one.
 Part of the creation process here is loading the plotly javascript.
 """
 function get_window(ed::ElectronDisplay; kwargs...)
-    if !isnull(ed.w) && active(get(ed.w))
+    if ed.w !== nothing && active(get(ed.w))
         w = get(ed.w)
     else
         w = get_window(Dict(kwargs))
@@ -94,11 +94,11 @@ svg_var(p::ElectronPlot) = svg_var(p.view)
 
 """
 Close the plot window (if active) and reset the fields and reset the `w` field
-on the display to be `Nullable()`.
+on the display to be `nothing`.
 """
 function Base.close(p::ElectronPlot)
     close(p.view)
-    p.view.w = Nullable()
+    p.view.w = nothing
     nothing
 end
 

--- a/src/displays/ijulia.jl
+++ b/src/displays/ijulia.jl
@@ -82,7 +82,7 @@ function init_notebook(force=false)
     end
 
     if !js_loaded(JupyterDisplay) || force
-        _ijulia_js = readstring(joinpath(dirname(@__FILE__), "ijulia.js"))
+        _ijulia_js = read(joinpath(dirname(@__FILE__), "ijulia.js"), String)
 
         # three script tags for loading ijulia setup, and plotly
         display("text/html", """
@@ -92,7 +92,7 @@ function init_notebook(force=false)
 
         <script charset="utf-8" type='text/javascript'>
             define('plotly', function(require, exports, module) {
-                $(open(readstring, _js_path, "r"))
+                $(open(f->read(f, String), _js_path, "r"))
             });
             require(['plotly'], function(Plotly) {
                 window.Plotly = Plotly;

--- a/src/displays/ijulia.jl
+++ b/src/displays/ijulia.jl
@@ -148,22 +148,22 @@ end
 # Javascript API methods #
 # ---------------------- #
 
-relayout!(jd::JupyterDisplay, update::Associative=Dict(); kwargs...) =
+relayout!(jd::JupyterDisplay, update::AbstractDict=Dict(); kwargs...) =
     _call_plotlyjs(jd, "relayout", merge(update, prep_kwargs(kwargs)))
 
-restyle!(jd::JupyterDisplay, ind::Int, update::Associative=Dict(); kwargs...) =
+restyle!(jd::JupyterDisplay, ind::Int, update::AbstractDict=Dict(); kwargs...) =
     _call_plotlyjs(jd, "restyle", merge(update, prep_kwargs(kwargs)), ind-1)
 
 function restyle!(jd::JupyterDisplay, inds::AbstractVector{Int},
-                  update::Associative=Dict();  kwargs...)
+                  update::AbstractDict=Dict();  kwargs...)
     _call_plotlyjs(jd, "restyle", merge(update, prep_kwargs(kwargs)), inds-1)
 end
 
-restyle!(jd::JupyterDisplay, update::Associative=Dict(); kwargs...) =
+restyle!(jd::JupyterDisplay, update::AbstractDict=Dict(); kwargs...) =
     _call_plotlyjs(jd, "restyle", merge(update, prep_kwargs(kwargs)))
 
 function update!(
-        jd::JupyterDisplay, ind::Int, update::Associative=Dict();
+        jd::JupyterDisplay, ind::Int, update::AbstractDict=Dict();
         layout::Layout=Layout(), kwargs...
     )
     _call_plotlyjs(jd, "update", merge(update, prep_kwargs(kwargs)), layout, ind-1)
@@ -171,13 +171,13 @@ end
 
 function update!(
         jd::JupyterDisplay, inds::AbstractVector{Int},
-        update::Associative=Dict(); layout::Layout=Layout(), kwargs...
+        update::AbstractDict=Dict(); layout::Layout=Layout(), kwargs...
     )
     _call_plotlyjs(jd, "update", merge(update, prep_kwargs(kwargs)), layout, inds-1)
 end
 
 function update!(
-        jd::JupyterDisplay, update::Associative=Dict();
+        jd::JupyterDisplay, update::AbstractDict=Dict();
         layout::Layout=Layout(),  kwargs...
     )
     _call_plotlyjs(jd, "update", merge(update, prep_kwargs(kwargs)), layout)
@@ -208,11 +208,11 @@ download_image(jd::JupyterDisplay; kwargs...) =
     _call_plotlyjs(jd, "download_image", Dict(kwargs))
 
 # unexported (by plotly.js) api methods
-extendtraces!(jd::JupyterDisplay, update::Associative=Dict(),
+extendtraces!(jd::JupyterDisplay, update::AbstractDict=Dict(),
               indices::Vector{Int}=[1], maxpoints=-1;) =
     _call_plotlyjs(jd, "extendTraces", update, indices-1, maxpoints)
 
-prependtraces!(jd::JupyterDisplay, update::Associative=Dict(),
+prependtraces!(jd::JupyterDisplay, update::AbstractDict=Dict(),
                indices::Vector{Int}=[1], maxpoints=-1;) =
     _call_plotlyjs(jd, "prependTraces", update, indices-1, maxpoints)
 


### PR DESCRIPTION
Hi!

Here I fixed issues with `Nullable`, `readstring`, `AbstractDictionary`, `Markdown` and `reexport`.
This version still doesn't work on Julia 0.7 because of problems in [Blink.jl](https://github.com/JunoLab/Blink.jl/pull/133), which, if I understood correctly, goes further to [WebIO](https://github.com/JuliaGizmos/WebIO.jl/pull/157). Though now it at least can be built.