### PR TITLE
Import html_body from PlotlyBase

### DIFF
--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -11,7 +11,7 @@ import PlotlyBase:
     restyle!, relayout!, update!, addtraces!, deletetraces!, movetraces!,
     redraw!, extendtraces!, prependtraces!, purge!, to_image, download_image,
     restyle, relayout, update, addtraces, deletetraces, movetraces, redraw,
-    extendtraces, prependtraces, prep_kwargs, sizes, savefig, _tovec
+    extendtraces, prependtraces, prep_kwargs, sizes, savefig, _tovec, html_body
 
 using WebIO
 using JSExpr


### PR DESCRIPTION
It's used on [this line](https://github.com/sglyon/PlotlyJS.jl/blob/2fb2f20e40cd79777625f31f6c6fadc3b0bac14c/src/display.jl#L28)