### PR TITLE
ENH: enables dynamical plotting when run in terminal or atom

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -164,6 +164,13 @@ function Base.display(::REPL.REPLDisplay, p::SyncPlot)
     Blink.body!(p.window, p.scope)
 end
 
+Base.display(p::SyncPlot) = display_blink(p)
+
+function display_blink(p::SyncPlot)
+    p.window = Blink.Window()
+    Blink.body!(p.window, p.scope)
+end
+
 function Base.close(p::SyncPlot)
     if p.window !== nothing && Blink.active(p.window)
         close(p.window)


### PR DESCRIPTION
Related to Issue [223](https://github.com/sglyon/PlotlyJS.jl/issues/223). Enables using of dynamical plotting with `extendtraces!`