### PR TITLE
Do not recursively call JSON.lower

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -1,5 +1,5 @@
 PlotlyBase.trace_map(p::SyncPlot, axis) = trace_map(p.plot, axis)
-JSON.lower(sp::SyncPlot) = JSON.lower(sp.plot)
+JSON.lower(sp::SyncPlot) = sp.plot
 
 PlotlyBase._is3d(p::SyncPlot) = _is3d(p.plot)
 


### PR DESCRIPTION
JSON.lower is intended to replace the given argument with something which can be serialized by JSON. It is not guaranteed to work on all objects, in particular, it will not work on any objects which can already be serialized by JSON. `missing` is already serialized by JSON, and thus cannot be lowered any further.

The correct usage in this case is to simply return the serializable object directly, not to recursively call `lower` on that. `JSON` is able to handle chains of lowering:

```
julia> struct A end

julia> struct B end

julia> JSON.lower(::A) = B()

julia> JSON.lower(::B) = 1

julia> JSON.json(A())
"1"
```

I will check if we can make the documentation more clear on this. I believe this closes #265.