### PR TITLE
Add fix for WebIO 0.8.0+.

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -11,6 +11,10 @@ end
 Base.getindex(p::SyncPlot, key) = p.scope[key] # look up Observables
 
 WebIO.render(p::SyncPlot) = WebIO.render(p.scope)
+# WebIO 0.8.0+
+if isdefined(WebIO, :render_internal)
+    WebIO.render_internal(p::SyncPlot) = WebIO.render_internal(p.scope)
+end
 Base.show(io::IO, mm::MIME"text/html", p::SyncPlot) = show(io, mm, p.scope)
 Base.show(io::IO, mm::MIME"application/juno+plotpane", p::SyncPlot) = show(io, mm, p.scope)
 


### PR DESCRIPTION
There's still an issue with JupyterLab because the bundle tries to access the WebIO global (which doesn't exist in JupyterLab). This is a non-issue for simply displaying plots, but is an issue for interactive plots. I'll open a separate issue for the JupyterLab problem.