### PR TITLE
Add Base.show for WebIO node MIME.

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -15,6 +15,7 @@ WebIO.render(p::SyncPlot) = WebIO.render(p.scope)
 if isdefined(WebIO, :render_internal)
     WebIO.render_internal(p::SyncPlot) = WebIO.render_internal(p.scope)
 end
+Base.show(io::IO, m::WebIO.WEBIO_NODE_MIME, p::SyncPlot) = Base.show(io, m, p.scope)
 Base.show(io::IO, mm::MIME"text/html", p::SyncPlot) = show(io, mm, p.scope)
 Base.show(io::IO, mm::MIME"application/juno+plotpane", p::SyncPlot) = show(io, mm, p.scope)
 


### PR DESCRIPTION
Makes plots show up in Jupyter notebook.

This is part of a broader discussion about how to deal with this kind of thing (in an ideal world `WebIO.render(x::MyType) = ...` should make this work, but it doesn't right now and fixing that is non-trivial).