### PR TITLE
Modify plot window dimensions on creation to fit plot contents

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -152,7 +152,10 @@ Base.copy(sp::SyncPlot) = SyncPlot(copy(sp.plot), options=copy(sp.options))
 Base.display(::PlotlyJSDisplay, p::SyncPlot) = display_blink(p::SyncPlot)
 
 function display_blink(p::SyncPlot)
-    p.window = Blink.Window()
+    sizeBuffer = 1.15
+    plotSize = size(p.plot)
+    windowOptions = Dict("width"=>floor(Int,plotSize[1]*sizeBuffer), "height"=>floor(Int,plotSize[2]*sizeBuffer))
+    p.window = Blink.Window(windowOptions)
     Blink.body!(p.window, p.scope)
 end
 


### PR DESCRIPTION
The previous behavior was to rescale the plot contents to fit the default window size on creation.
This update modifies the window dimensions to fit the plot contents.

Issue: 314