### PR TITLE
support :include_mathjax optionMathjax Option

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Spencer Lyon <spencerlyon2@gmail.com>"]
 version = "0.13.1"
 
 [deps]
+AssetRegistry = "bf4720bc-e11a-5d0c-854e-bdca1663c893"
 Blink = "ad839575-38b3-5650-b840-f874b8c74a25"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -14,6 +14,7 @@ import PlotlyBase:
     react, react!
 
 using WebIO
+using AssetRegistry
 using JSExpr
 using JSExpr: @var, @new
 using Blink
@@ -26,7 +27,7 @@ const _pkg_root = dirname(dirname(@__FILE__))
 const _js_path = joinpath(_pkg_root, "assets", "plotly-latest.min.js")
 const _js_cdn_path = "https://cdn.plot.ly/plotly-latest.min.js"
 const _mathjax_cdn_path =
-    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_SVG"
+    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-AMS-MML_SVG"
 
 struct PlotlyJSDisplay <: AbstractDisplay end
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -201,7 +201,7 @@ function mathjax_path(p::SyncPlot)
         mathjax = p.plot.layout[:include][:mathjax]
     catch
         # if called from Plot's plotlyjs() backend, the extra_kwargs are passed literally, i.e `:include_mathjax`
-        mathjax = get(p.plot.layout, :include_mathjax, "")
+        mathjax = get(p.plot.layout.fields, :include_mathjax, "")
     end
     # convert "cdn" and "local" to the respective online or local mathjax paths
     return mathjax_path(mathjax)

--- a/src/display.jl
+++ b/src/display.jl
@@ -156,7 +156,55 @@ function display_blink(p::SyncPlot)
     plotSize = size(p.plot)
     windowOptions = Dict("width"=>floor(Int,plotSize[1]*sizeBuffer), "height"=>floor(Int,plotSize[2]*sizeBuffer))
     p.window = Blink.Window(windowOptions)
+
+    # check if the inlcude_mathjax option is set and add the respective header
+    # the syntax is chosen identical to the python version: Layout(include_mathjax = <mathjax_path>)
+    mathjax = mathjax_path(p)
+    mathjax == "" || try
+        # if file is local then add the mathjax path to the asset registry
+        # Currently `WebIO` does not support registering of directories, PR is pending ...
+        # otherwise we could do: `mathjax = WebIO.dep2url(mathjax)`
+        # so we have to use `AssetRegistry` directly
+        if WebIO.islocal(mathjax)
+            mathjax = joinpath(AssetRegistry.register(dirname(mathjax)), basename(mathjax))
+        end
+        # add the mathjax file to the <head> section
+        Blink.loadjs!(p.window, mathjax)
+    catch
+        @warn """Could not verify mathjax path!
+
+        Consider installing IJulia.
+        Currently, however, TexFonts need to be installed manually... :-(
+        """
+    end
+
     Blink.body!(p.window, p.scope)
+end
+
+# convert "cdn" and "local" to the respective online or local mathjax-paths
+function mathjax_path(mj::AbstractString)
+    if mj == "cdn"
+        return _mathjax_cdn_path
+    elseif mj == "local"
+        mj = abspath(first(DEPOT_PATH), "conda", "3", "Lib", "site-packages",
+                    "notebook", "static", "components", "MathJax", "MathJax.js")
+        return isfile(mj) ? (mj * "?config=TeX-AMS-MML_HTMLorMML-full") : ""
+    end
+    return mj
+end
+
+# retrieve the mathjax option from the SyncPlot
+function mathjax_path(p::SyncPlot)
+    local mathjax
+    try
+        # Layout(include_mathjax = ...) results in a layout field :include with a dictionary entry :mathjax
+        mathjax = p.plot.layout[:include][:mathjax]
+    catch
+        # if called from Plot's plotlyjs() backend, the extra_kwargs are passed literally, i.e `:include_mathjax`
+        mathjax = get(p.plot.layout, :include_mathjax, "")
+    end
+    # convert "cdn" and "local" to the respective online or local mathjax paths
+    return mathjax_path(mathjax)
 end
 
 function Base.close(p::SyncPlot)


### PR DESCRIPTION
I recently committed an `:include_mathjax` option for the plotly() backend in plot and wondered, whether I could reuse my experience for PlotlyJS and its respective Backend in plots.
This is, what I ended up with. This probably solves #60 and #78, at least partly.

WebIO currently does not support registering of directories with its `dep2url` routine and has some missing Windows support, which I addressed in https://github.com/JuliaGizmos/WebIO.jl/pull/417

Meanwhile, I used `AssetRegistry` directly to work around this problem.

Usage: add `include_mathjax = <mathjaxpath>` to the Layout options.
mathjaxpath can be either "cdn", "local" (which looks whether mathjax is installed with IJulia) or a direct link to a mathjax file (local or remote).

Unfortunately, I couldn't find a way to implement this for the plot pane. MathJax only works, if the mathjax source is included in the head tag.
I have experimented with a script that appends MathJax to the header after document was loaded, but that version also only worked for the Blink display, so I chose to use this version, which is somehow cleaner.
Maybe, someone else can help?
Example:

```using PlotlyJS
plot(scatter(y=[2,3]), Layout(xaxis_title="\$\\Gamma\$", include_mathjax = "cdn"))
```
or  from the Plots plotlyjs() backend
```using Plots
plot(1:2, include_mathjax="cdn", extra_kwargs = :plot, xlabel = "\$\\Gamma_1\$")
```